### PR TITLE
GeoGebra calculator

### DIFF
--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -9148,15 +9148,6 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 
 <xsl:template match="*" mode="calculator">
     <xsl:if test="$b-has-calculator and contains($html.calculator,'geogebra')">
-        <!-- <style>
-            .geogebra-container {
-                position: fixed;
-                bottom: 20px;
-                right: 10px;
-                width: 320px;
-                height: 600px;
-            }
-        </style> -->
         <div id="calculator-container" class="calculator-container" style="display: none">
             <div id="geogebra-calculator"></div>
         </div>
@@ -9194,11 +9185,9 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                 "autoHeight": true,
                 "disableAutoScale": false},
             true);
-<!--
-            window.addEventListener("load", function() {
-                ggbApp.inject('geogebra-calculator');
-            });
--->
+            <!--   The calculator is created by                    -->
+            <!--   ggbApp.inject('geogebra-calculator');           -->
+            <!--   which is inserted by code in pretext_add_on.js  -->
             </xsl:text>
         </script>
     </xsl:if>

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -140,7 +140,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:param name="html.css.server" select="'https://pretextbook.org'" />
 <xsl:param name="html.css.version" select="'0.2'" />
 <xsl:param name="html.js.server" select="'https://pretextbook.org'" />
-<xsl:param name="html.js.version" select="'0.1'" />
+<xsl:param name="html.js.version" select="'0.11'" />
 <xsl:param name="html.css.colorfile" select="''" />
 <xsl:variable name="html-css-colorfile">
     <xsl:choose>
@@ -8906,6 +8906,22 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
     </xsl:choose>
 </xsl:template>
 
+<xsl:template match="*" mode="calculator-toggle">
+    <xsl:element name="div">
+        <xsl:attribute name="id">
+            <xsl:text>calculator-toggle</xsl:text>
+        </xsl:attribute>
+        <xsl:attribute name="class">
+            <xsl:text>toolbar-item button toggle</xsl:text>
+        </xsl:attribute>
+        <xsl:attribute name="title">
+            <xsl:text>Show calculator</xsl:text>
+        </xsl:attribute>
+        <xsl:text>Calc</xsl:text>
+    </xsl:element>
+</xsl:template>
+
+
 <!-- Compact Buttons -->
 <!-- These get smashed consecutively into a single "tool-bar" -->
 <xsl:template match="*" mode="compact-buttons">
@@ -9012,6 +9028,12 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                                 <xsl:otherwise>
                                     <xsl:apply-templates select="." mode="index-button" />
                                 </xsl:otherwise>
+                            </xsl:choose>
+                            <!-- Botton to show/hide the calculator -->
+                            <xsl:choose>
+                                <xsl:when test="$b-has-calculator">
+                                    <xsl:apply-templates select="." mode="calculator-toggle" />
+                                </xsl:when>
                             </xsl:choose>
                             <!-- Span to encase Prev/Up/Next buttons and float right    -->
                             <!-- Each button gets an id for keypress recognition/action -->
@@ -9134,7 +9156,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                 height: 600px;
             }
         </style> -->
-        <div id="geogebra-container" class="geogebra-container">
+        <div id="calculator-container" class="calculator-container" style="display: none">
             <div id="geogebra-calculator"></div>
         </div>
         <script>
@@ -9155,7 +9177,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
             <!-- All the rest is customizing some things away from defaults -->
             <!-- (or maybe in some cases explicitly using the defaults)     -->
             <!-- The last parameters have to do with scaling. This combination allows the 320x600 applet to scale up -->
-            <!-- to the size of the geogebra-container (class) div. The applet will only scale proportionately. With -->
+            <!-- to the size of the #calculator-container div. The applet will only scale proportionately. With -->
             <!-- the setup below, only the width can constrain it.                                                   -->
             <xsl:text>
                 "width": 320,
@@ -9165,8 +9187,8 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                 "perspective": "G/A",
                 "algebraInputPosition": "bottom",
                 <!-- "appletOnLoad": onLoad, -->
-                "showFullscreenButton": true,
-                "scaleContainerClass": "geogebra-container",
+                "showFullscreenButton": false,
+                "scaleContainerClass": "calculator-container",
                 "allowUpscale": true,
                 "autoHeight": true,
                 "disableAutoScale": false},

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -7552,6 +7552,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
        <xsl:text>var role = 'student';&#xa;</xsl:text>
        <xsl:text>var guest_access = true;&#xa;</xsl:text>
        <xsl:text>var login_required = false;&#xa;</xsl:text>
+       <xsl:text>var js_version = </xsl:text><xsl:value-of select='$html.js.version'/><xsl:text>;&#xa;</xsl:text>
     </script>
 </xsl:template>
 
@@ -9193,9 +9194,11 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                 "autoHeight": true,
                 "disableAutoScale": false},
             true);
+<!--
             window.addEventListener("load", function() {
                 ggbApp.inject('geogebra-calculator');
             });
+-->
             </xsl:text>
         </script>
     </xsl:if>
@@ -9706,6 +9709,7 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
     <script src="{$html.js.server}/js/lib/jquery.sticky.js" ></script>
     <script src="{$html.js.server}/js/lib/jquery.espy.min.js"></script>
     <script src="{$html.js.server}/js/{$html.js.version}/pretext.js"></script>
+    <script src="{$html.js.server}/js/{$html.js.version}/pretext_add_on.js"></script>
 </xsl:template>
 
 <!-- Font header -->

--- a/xsl/mathbook-html.xsl
+++ b/xsl/mathbook-html.xsl
@@ -155,6 +155,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <!-- A space-separated list of CSS URLs (points to servers or local files) -->
 <xsl:param name="html.css.extra"  select="''" />
 
+<!-- Calculator -->
+<!-- Possible values are geogebra-classic, geogebra-graphing -->
+<!-- geogebra-geometry, geogebra-3d                          -->
+<!-- Default is empty, meaning the calculator is not wanted. -->
+<xsl:param name="html.calculator" select="''" />
+<xsl:variable name="b-has-calculator" select="not($html.calculator = '')" />
+
 <!-- Annotation -->
 <xsl:param name="html.annotation" select="''" />
 <xsl:variable name="b-activate-hypothesis" select="boolean($html.annotation='hypothesis')" />
@@ -8352,7 +8359,10 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
                         <xsl:copy-of select="$content" />
                     </div>
                 </main>
+                <!-- Overlaid extras, such as a calculator -->
+                <xsl:apply-templates select="." mode="overlays" />
             </div>
+
             <xsl:apply-templates select="$docinfo/analytics" />
             <xsl:call-template name="pytutor-footer" />
             <xsl:call-template name="login-footer" />
@@ -9045,6 +9055,69 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
         </aside> -->
 </xsl:template>
 
+<!-- Overlays -->
+<!-- For example, a graphing calculator tool       -->
+<xsl:template match="*" mode="overlays">
+    <xsl:apply-templates select="." mode="calculator" />
+</xsl:template>
+
+<xsl:template match="*" mode="calculator">
+    <xsl:if test="$b-has-calculator and contains($html.calculator,'geogebra')">
+        <!-- <style>
+            .geogebra-container {
+                position: fixed;
+                bottom: 20px;
+                right: 10px;
+                width: 320px;
+                height: 600px;
+            }
+        </style> -->
+        <div id="geogebra-container" class="geogebra-container">
+            <div id="geogebra-calculator"></div>
+        </div>
+        <script>
+            <xsl:text>
+            <!-- Here is where we could initialize some things to customize the display.                    -->
+            <!-- But the customization should be different depending on classic, graphing, geometry, or 3d. -->
+            <!-- For instance geometry probably does not benefit from showing the grid.                     -->
+            <!-- If this is not in use, no need to set "appletOnLoad" further below.                        -->
+            <!-- var onLoad = function(applet) {
+                applet.setAxisLabels(1,'x','y','z');
+                applet.setGridVisible(1,true);
+                applet.showFullscreenButton(true);
+            }; -->
+            var ggbApp = new GGBApplet({"appName": "</xsl:text>
+            <xsl:value-of select="substring-after($html.calculator,'-')"/>
+            <xsl:text>", </xsl:text>
+            <!-- width and height are required parameters                   -->
+            <!-- All the rest is customizing some things away from defaults -->
+            <!-- (or maybe in some cases explicitly using the defaults)     -->
+            <!-- The last parameters have to do with scaling. This combination allows the 320x600 applet to scale up -->
+            <!-- to the size of the geogebra-container (class) div. The applet will only scale proportionately. With -->
+            <!-- the setup below, only the width can constrain it.                                                   -->
+            <xsl:text>
+                "width": 320,
+                "height": 600,
+                "showToolBar": true,
+                "showAlgebraInput": true,
+                "perspective": "G/A",
+                "algebraInputPosition": "bottom",
+                <!-- "appletOnLoad": onLoad, -->
+                "showFullscreenButton": true,
+                "scaleContainerClass": "geogebra-container",
+                "allowUpscale": true,
+                "autoHeight": true,
+                "disableAutoScale": false},
+            true);
+            window.addEventListener("load", function() {
+                ggbApp.inject('geogebra-calculator');
+            });
+            </xsl:text>
+        </script>
+    </xsl:if>
+</xsl:template>
+
+
 <!-- Table of Contents Contents (Items) -->
 <!-- Includes "active" class for enclosing outer node              -->
 <!-- Node set equality and subset based on unions of subtrees, see -->
@@ -9578,10 +9651,9 @@ var </xsl:text><xsl:value-of select="$applet-parameters" /><xsl:text> = {
 </xsl:template>
 
 <!-- GeoGebra -->
-<!-- The JS necessary to load the "App", which can -->
-<!-- then be loaded with base64 or XML versions    -->
+<!-- The JS necessary to load the "App" for a generic calculator -->
 <xsl:template name="geogebra">
-    <xsl:if test="$b-has-geogebra">
+    <xsl:if test="$b-has-calculator and contains($html.calculator,'geogebra')">
         <script src="https://cdn.geogebra.org/apps/deployggb.js"></script>
     </xsl:if>
 </xsl:template>


### PR DESCRIPTION
Small adjustments to the calculator setup.

Added a button (next to "Index") to show/hide the calculator.
(Did not test on document lacking an index.)

See elsewhere for CSS and Javascript to make things work.
Note that Javascript version changed to 0.11.

Compile with
    --stringparam html.calculator geogebra-classic

Feel free to just copy my changes, or smash into one commit.